### PR TITLE
update pyproject.toml to configure ruff.lint and ruff.format

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,31 +6,7 @@ pretty = true
 [[tool.mypy.overrides]]
 directories = "tests"  # Allow untyped tests.
 
-[tool.black]
-line-length = 88
-target-version = ['py311']
-
 [tool.ruff]
-# Assume Python 3.11.
-target-version = "py311"
-
-select = [
-    "E",     # pycodestyle
-    "F",     # Pyflakes
-    "W",     # pycodestyle warnings
-    "C901",  # McCabe complexity
-    "N",     # pep8-naming
-    "D",     # pydocstyle
-    "UP",    # pyupgrade
-    "PL"     # pylint
-]
-
-ignore = ["D100", "D104"]
-
-# Allow autofix for all enabled rules (when `--fix`) is provided.
-fixable = ["ALL"]
-unfixable = []
-
 # Exclude a variety of commonly ignored directories.
 exclude = [
     ".bzr",
@@ -39,32 +15,58 @@ exclude = [
     ".git",
     ".git-rewrite",
     ".hg",
+    ".ipynb_checkpoints",
     ".mypy_cache",
     ".nox",
     ".pants.d",
+    ".pyenv",
+    ".pytest_cache",
     ".pytype",
     ".ruff_cache",
     ".svn",
     ".tox",
     ".venv",
+    ".vscode",
     "__pypackages__",
     "_build",
     "buck-out",
     "build",
     "dist",
     "node_modules",
+    "site-packages",
     "venv",
 ]
 
-per-file-ignores = {}
-
 # Same as Black.
 line-length = 88
+indent-width = 4
+
+# Assume Python 3.11
+target-version = "py311"
+
+[tool.ruff.lint]
+select = [
+    "E",     # pycodestyle
+    "F",     # Pyflakes
+    "W",     # pycodestyle warnings
+    "C901",  # McCabe complexity
+    "N",     # pep8-naming
+    "D",     # pydocstyle
+    "UP",    # pyupgrade
+    "PL",     # pylint
+    "I"      # isort
+]
+
+ignore = ["D100", "D104"]
+
+# Allow autofix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]
+unfixable = []
 
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
-[tool.ruff.extend-per-file-ignores]
+[tool.ruff.lint.extend-per-file-ignores]
 "test_*.py" = [
     "D101",  # Missing docstring in public class
     "D102",  # Missing docstring in public method
@@ -76,13 +78,34 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
     "D103",  # Missing docstring in public function
 ]
 
-[tool.ruff.mccabe]
+[tool.ruff.lint.mccabe]
 # Flag errors (`C901`) whenever the complexity level exceeds 10.
 max-complexity = 10
 
-[tool.ruff.pydocstyle]
+[tool.ruff.lint.pydocstyle]
 # Use Google-style docstrings.
 convention = "google"
+
+[tool.ruff.format]
+# Like Black, use double quotes for strings.
+quote-style = "double"
+
+# Like Black, indent with spaces, rather than tabs.
+indent-style = "space"
+
+# Like Black, respect magic trailing commas.
+skip-magic-trailing-comma = false
+
+# Like Black, automatically detect the appropriate line ending.
+line-ending = "auto"
+
+# Enable auto-formatting of code examples in docstrings. Markdown,
+# reStructuredText code/literal blocks and doctests are all supported.
+docstring-code-format = true
+
+# Set the line length limit used when formatting code snippets in
+# docstrings.
+docstring-code-line-length = "dynamic"
 
 [tool.pytest.ini_options]
 minversion = "6.0"
@@ -90,12 +113,3 @@ addopts = "-ra -q"
 testpaths = [
     "tests",
 ]
-
-# Placeholders for future configuration if required.
-[tool.ruff.isort]
-
-[tool.ruff.pep8-naming]
-
-[tool.ruff.pylint]
-
-[tool.ruff.pyupgrade]


### PR DESCRIPTION
Configuration settings updated in pyproject.toml due to change from using Black to Ruff to format code.  