### PR TITLE
update requirements-dev.in

### DIFF
--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,6 +1,4 @@
 -c requirements.txt
-black
-pip-tools
 pre-commit
 pytest
 ruff


### PR DESCRIPTION
Removes pip-compile and Black. Black has been replaced by Ruff formater.